### PR TITLE
feature(cache): add support for ttls

### DIFF
--- a/lib/Cache.js
+++ b/lib/Cache.js
@@ -1,9 +1,12 @@
 /**
  * Construct a new Cache object
  */
-var Cache = module.exports = function () {
+var Cache = module.exports = function (options) {
+  this.__options = options || {};
   this.clear();
 };
+
+var FOREVER = 0;
 
 Cache.prototype = {
   put: put,
@@ -19,12 +22,14 @@ Cache.prototype = {
  *
  * @param {String} key The key that the value will be cached with
  * @param {Object} val The value of the cache entry
+ * @param {Number} [ttl 30000] The ttl before this entry expires in milli-seconds
  */
-function put(key, val) {
+function put(key, val, ttl) {
   // Don't increment size if key already exists
   if (typeof this.__store[key] === 'undefined') {
     this.__size++;
   }
+  this.__ttl[key] = getExpiryDateFor(ttl || this.__options.maxAge);
   this.__store[key] = val;
 };
 
@@ -35,7 +40,13 @@ function put(key, val) {
  * @returns {Object} The value associated with `key`, otherwise undefined
  */
 function get(key) {
-  return this.__store[key];
+  var ttl = this.__ttl[key];
+
+  if (!ttl || ttl === FOREVER || Date.now() < ttl) {
+    return this.__store[key];
+  }
+
+  return this.remove(key);
 };
 
 /**
@@ -47,6 +58,7 @@ function remove(key) {
   // Don't decrement if key doesn't exist
   if (typeof this.__store[key] !== 'undefined') {
     this.__size--;
+    delete this.__ttl[key];
   }
   delete this.__store[key];
 };
@@ -57,6 +69,7 @@ function remove(key) {
 function clear() {
   this.__size = 0;
   this.__store = {};
+  this.__ttl = {};
 };
 
 /**
@@ -91,3 +104,11 @@ var oKeys = Object.keys || function (obj) {
   }
   return result;
 };
+
+function getExpiryDateFor(ttl) {
+  if (!ttl) {
+    return FOREVER;
+  }
+
+  return Date.now() + ttl;
+}

--- a/lib/Factory.js
+++ b/lib/Factory.js
@@ -6,10 +6,11 @@ var __store = {};
  * Construct a Cache object
  *
  * @param {String} id The id of the cache
+ * @param {Object} options The configuration options for the cache
  * @returns {Cache} The newly created cache
  */
-Factory.create = function (id) {
-  __store[id] = new Cache();
+Factory.create = function (id, options) {
+  __store[id] = new Cache(options);
   return __store[id];
 };
 

--- a/specs/Cache.spec.js
+++ b/specs/Cache.spec.js
@@ -7,7 +7,7 @@ describe('Cache', function () {
   var cache;
 
   beforeEach(function () {
-    cache = Factory.create();
+    cache = Factory.create('forever_ttl');
   });
 
   afterEach(function () {
@@ -84,5 +84,22 @@ describe('Cache', function () {
 
     cache.clear();
     equal(cache.size(), 0);
+  });
+
+  it('should respect an explicit ttl', function (done) {
+    cache.put('foo', 123, 500);
+    setTimeout(function () {
+      equal(cache.get('foo'), undefined);
+      done()
+    }, 750);
+  });
+
+  it('should respect the default ttl', function(done) {
+    cache = Factory.create('expiring ttl', {maxAge: 500});
+    cache.put('foo', 123);
+    setTimeout(function () {
+      equal(cache.get('foo'), undefined);
+      done();
+    }, 750);
   });
 });


### PR DESCRIPTION
TTLs can either be specified on a per-object or global basis, with 0 being a magical value meaning all of time. Perhaps this constitutes v1.0?

Closes #3
